### PR TITLE
Exposed parameters for rms::lrm in rundif and runolr

### DIFF
--- a/R/rundif.R
+++ b/R/rundif.R
@@ -1,5 +1,5 @@
 rundif <-
-function(item,resp,theta,gr,criterion,alpha,beta.change,pseudo.R2,R2.change,wt) {
+function(item,resp,theta,gr,criterion,alpha,beta.change,pseudo.R2,R2.change,wt,...) {
     ncat<-apply(resp,2,max,na.rm=T) 
     ni<-length(item)
     beta12<-numeric(ni)
@@ -20,8 +20,8 @@ function(item,resp,theta,gr,criterion,alpha,beta.change,pseudo.R2,R2.change,wt) 
     pseudo23.McFadden<-numeric(ni)
     flag.post<-logical(ni)
     for (i in 1:ni) {
-      output<-try(runolr(resp[,i],theta,as.factor(gr),wt),silent=T)
-      if (inherits(output,"try-error")) output<-runolr(resp[,i],log((theta-min(theta)+0.01)/(max(theta)-theta+.01)),as.factor(gr),wt)
+      output<-try(runolr(resp[,i],theta,as.factor(gr),wt,...),silent=T)
+      if (inherits(output,"try-error")) output<-runolr(resp[,i],log((theta-min(theta)+0.01)/(max(theta)-theta+.01)),as.factor(gr),wt,...)
       if (exists("output")) {
         beta12[i]<-output$beta12
         chi12[i]<-output$chi12

--- a/R/runolr.R
+++ b/R/runolr.R
@@ -1,10 +1,10 @@
 runolr <-
-function(rv,ev,gr,wt) {
+function(rv,ev,gr,wt,...) {
     ng<-length(table(gr))
     nobs<-length(rv)
-    md1<-lrm(rv ~ ev, weights=wt)
-    md2<-lrm(rv ~ ev + gr, weights=wt)
-    md3<-lrm(rv ~ ev*gr, weights=wt)
+    md1<-lrm(rv ~ ev, weights=wt, ...)
+    md2<-update(md1, . ~ . + gr)
+    md3<-update(md1, . ~ . * gr)
     beta12<-round(abs((md2$coefficients[["ev"]]-md1$coefficients[["ev"]])/md1$coefficients[["ev"]]),4)
     deviance0<-md1$deviance[1]
     deviance1<-md1$deviance[2]

--- a/man/rundif.Rd
+++ b/man/rundif.Rd
@@ -7,7 +7,7 @@
   Runs ordinal logistic regression DIF
 }
 \usage{
-rundif(item, resp, theta, gr, criterion, alpha, beta.change, pseudo.R2, R2.change, wt)
+rundif(item, resp, theta, gr, criterion, alpha, beta.change, pseudo.R2, R2.change, wt, ...)
 }
 \arguments{
   \item{item}{ a selection of items to be analyzed }
@@ -20,6 +20,7 @@ rundif(item, resp, theta, gr, criterion, alpha, beta.change, pseudo.R2, R2.chang
   \item{pseudo.R2}{ pseudo R-squared measure (i.e., "McFadden", "Nagelkerke", or "CoxSnell") }
   \item{R2.change}{ R-squared change for pseudo R-squared criterion }
   \item{wt}{ optional sample weights }
+  \item{...}{ arguments passed to \code{rms::lrm} (or \code{rms::lrm.fit}) }
 }
 \details{
   The argument item lists the column numbers of the data frame resp to be included in the analysis.

--- a/man/runolr.Rd
+++ b/man/runolr.Rd
@@ -7,13 +7,14 @@
   Runs ordinal logistic regression models and produces DIF statistics and effect size measures
 }
 \usage{
-runolr(rv, ev, gr, wt)
+runolr(rv, ev, gr, wt, ...)
 }
 \arguments{
   \item{rv}{ a response variable }
   \item{ev}{ an explanatory variable (e.g., conditioning variable) }
   \item{gr}{ a vector of group identifiers }
   \item{wt}{ a vector of optional sample weights }
+  \item{...}{ arguments passed to \code{rms::lrm} (or \code{rms::lrm.fit}) }
 }
 \details{
   Model 1: ev


### PR DESCRIPTION
Exposed parameters for rms::lrm (and rms::lrm.fit) in rundif and runolr via dots to enable arguments to be specified or changed from their defaults.

Changed the hierarchical model building from calling rms::lrm directly to calling rms::lrm via stats::update for each change to the model to efficiently pass the same non-design arguments to the first rms::lrm call to all subsequent fits. stats::update should work as long as rms::lrm returns the call, which is currently the case - rms::lrm is returning the call via base::match.call.